### PR TITLE
Fixed IndexError in rfc3261.py

### DIFF
--- a/src/std/rfc3261.py
+++ b/src/std/rfc3261.py
@@ -254,7 +254,8 @@ class Message(object):
             firstheaders, body = value, '' # assume no body
         try: firstline, headers = firstheaders.split('\n', 1)
         except: raise ValueError, 'No first line found'
-        if firstline[-1] == '\r': firstline = firstline[:-1]
+        try: if firstline[-1] == '\r': firstline = firstline[:-1]
+		except: raise ValueError,'Empty string sent'
         a, b, c = firstline.split(' ', 2)
         try:    # try as response
             self.response, self.responsetext, self.protocol = int(b), c, a # throws error if b is not int.


### PR DESCRIPTION
It appears in some cases that an empty SIP message can be sent, which
crashes p2p-sip :
User._listener exception (<type 'exceptions.IndexError'>,
IndexError('string index out of range',), <traceback object at
0x7f1067dad878>)
Traceback (most recent call last):
File "/opt/r2sip/rtmplite/siprtmp.py", line 1342, in <module>
try: multitask.run()
File "/opt/r2sip/rtmplite/multitask.py", line 1202, in run
get_default_task_manager().run()
File "/opt/r2sip/rtmplite/multitask.py", line 897, in run
self.run_next()
File "/opt/r2sip/rtmplite/multitask.py", line 964, in run_next
output = task.send(input)
File "/opt/r2sip/p2p-sip/src/app/voip.py", line 280, in _listener
self.stack.received(data, remote)
File "/opt/r2sip/p2p-sip/src/std/rfc3261.py", line 487, in received
m._parse(data)
File "/opt/r2sip/p2p-sip/src/std/rfc3261.py", line 257, in _parse
if firstline[-1] == '\r': firstline = firstline[:-1]
IndexError: string index out of range

Added a try block which raise the following if execption is raised :
"Empty string sent".
